### PR TITLE
fix: Marking scenario and feature as passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix setting prefix from `cucumberTestRunner` to `cucumberTestExtension`
 - Rename setting `cwd` to `workingDirectory` for better understanding
+- Fix that scenarios and features were not correctly marked as passed
 - Add `rootDirectory` setting to be able to configure the path to the `node_modules` where Cucumber JS is installed
 
 ## [0.6.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0]
 
 - Fix setting prefix from `cucumberTestRunner` to `cucumberTestExtension`
 - Rename setting `cwd` to `workingDirectory` for better understanding

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cucumber-test-extension",
-    "version": "0.6.3",
+    "version": "0.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "cucumber-test-extension",
-            "version": "0.6.3",
+            "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
                 "@cucumber/gherkin": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cucumber-test-extension",
     "displayName": "CucumberJS Test Extension",
     "description": "Allow to discover, run and debug cucumber-js tests",
-    "version": "0.6.3",
+    "version": "0.7.0",
     "publisher": "aristotelos",
     "license": "MIT",
     "icon": "docs/images/logo.png",


### PR DESCRIPTION
Scenarios and features were not marked as passed, even after all steps succeeded. This was due to a line number mismatch.

Along with this, mark steps as passed during the run. This was broken when using root directory or working directory.