### PR TITLE
fix: Fix publish

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,7 @@
 .vscode/**
 .vscode-test/**
+out/test/**
+out/**/*.map
 src/**
 .gitignore
 .yarnrc
@@ -10,7 +12,6 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 node_modules
-out/
 tsconfig.config
 .prettierrc
 .eslintrc.json


### PR DESCRIPTION
Publish should not ignore the `./out` folder because we use `tsc` to compile to it.